### PR TITLE
Faster var seq

### DIFF
--- a/src/hts.h
+++ b/src/hts.h
@@ -68,7 +68,14 @@ inline std::vector<uint64> reads_per_group(uint64 n_reads,
 
     std::binomial_distribution<uint64> distr(n_reads, 0.5);
 
-    for (uint64 i = 0; i < probs.size(); i++) {
+    for (uint64 i = 0; i < (probs.size() - 1); i++) {
+
+        if (probs[i] >= 1) {
+            out[i] = n_reads;
+            return out;
+        }
+
+        if (probs[i] == 0) continue;
 
         // Update distribution:
         distr.param(std::binomial_distribution<uint64>::param_type(
@@ -88,6 +95,8 @@ inline std::vector<uint64> reads_per_group(uint64 n_reads,
             probs[j] /= sum_probs;
         }
     }
+
+    out.back() = n_reads;
 
     return out;
 
@@ -345,7 +354,7 @@ inline void write_reads_one_filetype_(const T& read_filler_base,
 
 
 #ifdef _OPENMP
-#pragma omp parallel num_threads(n_threads) shared(files) if (n_threads > 1)
+#pragma omp parallel num_threads(n_threads) default(shared) if (n_threads > 1)
 {
 #endif
 

--- a/src/hts.h
+++ b/src/hts.h
@@ -49,6 +49,86 @@ const std::vector<std::string> mm_nucleos = {"CAG", "TAG", "TCG", "TCA", "NNN"};
 
 
 
+/*
+ Samples for # reads per group (e.g., per variant, per chromosome).
+ It uses binomial distribution for a `n_reads` that decreases each iteration and a
+ `probs` vector whose values go up.
+ This is ~600x faster than doing separate samples (via AliasSampler) for every read.
+ */
+inline std::vector<uint64> reads_per_group(uint64 n_reads,
+                                           std::vector<double> probs) {
+
+    std::vector<uint64> out;
+    if (n_reads == 0 || probs.size() == 0) return out;
+
+    pcg64 eng = seeded_pcg();
+
+    double sum_probs = std::accumulate(probs.begin(), probs.end(), 0.0);
+    for (double& p : probs) p /= sum_probs;
+
+    out.reserve(probs.size());
+
+    std::binomial_distribution<uint64> distr(n_reads, 0.5);
+
+    for (uint64 i = 0; i < probs.size(); i++) {
+
+        // Update distribution:
+        distr.param(std::binomial_distribution<uint64>::param_type(
+                n_reads, probs[i]));
+
+        // Sample from binomial distribution:
+        out.push_back(distr(eng));
+
+        // Decrease `n_reads` based on # sampled:
+        n_reads -= out.back();
+        // If `n_reads` is zero, we can resize `out` and stop now:
+        if (n_reads == 0) {
+            out.resize(probs.size(), 0ULL);
+            break;
+        }
+
+        // Increase probabilities:
+        sum_probs = 1 - probs[i];
+        for (uint64 j = (i+1); j < probs.size(); j++) {
+            probs[j] /= sum_probs;
+        }
+    }
+
+    return out;
+
+}
+
+
+
+// Fill read from string rather than variant chromosome
+
+void fill_read__(const std::string& chrom,
+                 std::string& read,
+                 const uint64& read_start,
+                 const uint64& chrom_start,
+                 uint64 n_to_add) {
+
+    uint64 chrom_end = chrom_start + n_to_add - 1;
+    // Making sure chrom_end doesn't go beyond the chromosome bounds
+    if (chrom_end >= chrom.size()) {
+        chrom_end = chrom.size() - 1;
+        n_to_add = chrom.size() - chrom_start;
+    }
+
+    // Make sure the read is long enough (this fxn should never shorten it):
+    if (read.size() < n_to_add + read_start) read.resize(n_to_add + read_start, 'N');
+
+    for (uint64 i = 0; i < n_to_add; i++) {
+        read[(read_start + i)] = chrom[(chrom_start + i)];
+    }
+    return;
+
+}
+
+
+
+
+
 //' bgzip a file, potentially using multiple threads.
 //'
 //' @noRd
@@ -111,7 +191,7 @@ class ReadWriterOneThread {
 
 public:
 
-    T read_filler;
+    T* read_filler;
     const uint64 n_reads;           // # reads to create
     const uint64 read_pool_size;    // reads per pool
     uint64 reads_made;              // Number of reads already made
@@ -121,12 +201,12 @@ public:
     const uint64 n_read_ends;       // (1 for SE Illumina or PacBio, 2 for PE Illumina)
     std::vector<std::vector<char>> fastq_pools;
 
-    ReadWriterOneThread(const T& read_filler_base,
+    ReadWriterOneThread(T& read_filler_,
                         const uint64& n_reads_,
                         const uint64& read_pool_size_,
                         const double& prob_dup_,
                         const uint64& n_read_ends_)
-        : read_filler(read_filler_base),
+        : read_filler(&read_filler_),
           n_reads(n_reads_),
           read_pool_size(read_pool_size_),
           reads_made(0),
@@ -168,13 +248,20 @@ public:
      write to file
      */
     void create_reads(pcg64& eng) {
-        read_filler.template one_read<std::vector<char>>(fastq_pools, eng);
+        bool finished  = false;
+        read_filler->template one_read<std::vector<char>>(fastq_pools, finished, eng);
+        // This is if something happens inside `one_read` to make sequencing finished
+        if (finished) {
+            reads_made = n_reads;
+            do_write = true;
+            return;
+        }
         reads_made += n_read_ends;
         reads_in_pool += n_read_ends;
         double dup = runif_01(eng);
         while (dup < prob_dup && reads_made < n_reads &&
                reads_in_pool < read_pool_size) {
-            read_filler.template re_read<std::vector<char>>(fastq_pools, eng);
+            read_filler->template re_read<std::vector<char>>(fastq_pools, eng);
             reads_made += n_read_ends;
             reads_in_pool += n_read_ends;
             dup = runif_01(eng);
@@ -214,18 +301,20 @@ public:
 
 
 /*
- For one file type and read filler type, make Illumina reads and write them to file(s).
+ For one file type and read filler type, make sequencing reads and write them to file(s).
  Does most of the work of `write_reads_cpp_` below.
  This should only be called inside that function.
 
  `T` should be `[Illumina|PacBio]Reference` or `[Illumina|PacBio]Variants`.
+ `T` should have an `add_n_reads` method.
+
  `F` should be `FileUncomp`, `FileGZ`, or `FileBGZF`.
 
  */
 template <typename T, typename F>
 inline void write_reads_one_filetype_(const T& read_filler_base,
                                       const std::string& out_prefix,
-                                      const uint64& n_reads,
+                                      uint64 n_reads,
                                       const double& prob_dup,
                                       const uint64& read_pool_size,
                                       const uint64& n_read_ends,
@@ -233,7 +322,9 @@ inline void write_reads_one_filetype_(const T& read_filler_base,
                                       const int& compress,
                                       Progress& prog_bar) {
 
-    const std::vector<uint64> reads_per_thread = split_int(n_reads, n_threads);
+    n_reads /= n_read_ends;
+    std::vector<uint64> reads_per_thread = split_int(n_reads, n_threads);
+    for (uint64& i : reads_per_thread) i *= n_read_ends;
 
     // Generate seeds for random number generators (1 RNG per thread)
     const std::vector<std::vector<uint64>> seeds = mt_seeds(n_threads);
@@ -241,8 +332,15 @@ inline void write_reads_one_filetype_(const T& read_filler_base,
     // Create and open files:
     std::vector<F> files(n_read_ends);
     for (uint64 i = 0; i < n_read_ends; i++) {
-        std::string file_name = out_prefix + "_R" + std::to_string(i+1)+ ".fq";
+        std::string file_name = out_prefix + "_R" + std::to_string(i+1) + ".fq";
         files[i].set(file_name, compress);
+    }
+
+    // Create read filler for each thread:
+    std::vector<T> read_fillers;
+    for (uint64 i = 0; i < n_threads; i++) {
+        read_fillers.push_back(read_filler_base);
+        read_fillers.back().add_n_reads(reads_per_thread[i]);
     }
 
 
@@ -265,7 +363,7 @@ inline void write_reads_one_filetype_(const T& read_filler_base,
 
     uint64 reads_this_thread = reads_per_thread[active_thread];
 
-    ReadWriterOneThread<T,F> writer(read_filler_base, reads_this_thread,
+    ReadWriterOneThread<T,F> writer(read_fillers[active_thread], reads_this_thread,
                                     read_pool_size, prob_dup, n_read_ends);
 
     uint64 reads_written;
@@ -388,69 +486,24 @@ inline void write_reads_cpp_(const T& read_filler_base,
                 read_pool_size, n_read_ends, n_threads, compress, prog_bar);
     }
 
-
-}
-
-
-
-/*
- Samples for # reads per variant.
- It uses binomial distribution for a `n_reads` that decreases each iteration and a
- `variant_probs` vector whose values go up.
- This is ~600x faster than doing separate samples (via AliasSampler) for every read.
- */
-inline std::vector<uint64> read_per_var(uint64 n_reads,
-                                        std::vector<double> variant_probs) {
-
-    pcg64 eng = seeded_pcg();
-
-    double sum_probs = std::accumulate(variant_probs.begin(), variant_probs.end(), 0.0);
-    for (double& p : variant_probs) p /= sum_probs;
-
-    std::vector<uint64> out;
-    out.reserve(variant_probs.size());
-
-    std::binomial_distribution<uint64> distr(n_reads, 0.5);
-
-    for (uint64 i = 0; i < variant_probs.size(); i++) {
-
-        // Update distribution:
-        distr.param(std::binomial_distribution<uint64>::param_type(
-                n_reads, variant_probs[i]));
-
-        // Sample from binomial distribution:
-        out.push_back(distr(eng));
-
-        // Decrease `n_reads` based on # sampled:
-        n_reads -= out.back();
-        // If `n_reads` is zero, we can resize `out` and stop now:
-        if (n_reads == 0) {
-            out.resize(variant_probs.size(), 0ULL);
-            break;
-        }
-
-        // Increase probabilities:
-        sum_probs = 1 - variant_probs[i];
-        for (uint64 j = (i+1); j < variant_probs.size(); j++) {
-            variant_probs[j] /= sum_probs;
-        }
-    }
-
-    return out;
+    return;
 
 }
 
 
 
 
+
 /*
- Same as above, but for when you want a separate file per variant
+ Same as above, but for when you want a separate file per variant.
+
+ So `T` should be `[Illumina|PacBio]Variants`.
  */
 
 template <typename T>
 inline void write_reads_cpp_sep_files_(const VarSet& var_set,
                                        const std::vector<double>& variant_probs,
-                                       T& read_filler_base,
+                                       T read_filler_base,
                                        const std::string& out_prefix,
                                        const uint64& n_reads,
                                        const double& prob_dup,
@@ -462,8 +515,8 @@ inline void write_reads_cpp_sep_files_(const VarSet& var_set,
                                        Progress& prog_bar) {
 
     // Sample for reads per file:
-    std::vector<uint64> reads_per_file = read_per_var(n_reads / n_read_ends,
-                                                      variant_probs);
+    std::vector<uint64> reads_per_file = reads_per_group(n_reads / n_read_ends,
+                                                         variant_probs);
     if (n_read_ends > 1) for (uint64& rpf : reads_per_file) rpf *= n_read_ends;
 
     // Now do each variant as separate file:
@@ -474,7 +527,7 @@ inline void write_reads_cpp_sep_files_(const VarSet& var_set,
         if (prog_bar.check_abort()) break;
 
         var_probs_[i] = 1;
-        read_filler_base.variant_sampler = AliasSampler(var_probs_);
+        read_filler_base.var_probs = var_probs_;
 
         std::string out_prefix_ = out_prefix + '_' + var_set[i].name;
 

--- a/src/hts.h
+++ b/src/hts.h
@@ -261,7 +261,12 @@ public:
         double dup = runif_01(eng);
         while (dup < prob_dup && reads_made < n_reads &&
                reads_in_pool < read_pool_size) {
-            read_filler->template re_read<std::vector<char>>(fastq_pools, eng);
+            read_filler->template re_read<std::vector<char>>(fastq_pools, finished, eng);
+            if (finished) {
+                reads_made = n_reads;
+                do_write = true;
+                return;
+            }
             reads_made += n_read_ends;
             reads_in_pool += n_read_ends;
             dup = runif_01(eng);

--- a/src/hts_illumina.h
+++ b/src/hts_illumina.h
@@ -624,7 +624,7 @@ public:
         // split # reads by variant
         if (paired) n_reads /= 2; // now it's pairs of reads
         std::vector<uint64> var_reads = reads_per_group(n_reads, var_probs);
-        if (paired) for (uint64& r : var_reads) r *= 2;  // back to # reads
+
         // splitting by chromosome, too:
         for (uint64 v = 0; v < n_vars; v++) {
             std::vector<double> chrom_probs;
@@ -632,6 +632,7 @@ public:
                 chrom_probs.push_back(vc.size());
             }
             n_reads_vc.push_back(reads_per_group(var_reads[v], chrom_probs));
+            if (paired) for (uint64& r : n_reads_vc.back()) r *= 2;  // back to # reads
         }
 
         // Fill `read_makers` field:

--- a/src/hts_illumina.h
+++ b/src/hts_illumina.h
@@ -295,8 +295,6 @@ class IlluminaOneGenome {
 public:
 
     /* __ Samplers __ */
-    // Samples index for which genome-chromosome to chromosome
-    AliasSampler chrom_sampler;
     // Samples Illumina qualities and errors, one `IlluminaQualityError` for each read
     std::vector<IlluminaQualityError> qual_errors;
     // Samples fragment lengths:
@@ -304,8 +302,9 @@ public:
 
 
     /* __ Info __ */
-    std::vector<uint64> chrom_lengths;    // genome-chromosome lengths
-    const T* chromosomes;                 // pointer to `const T`
+    std::vector<uint64> chrom_reads;    // # reads per chromosome
+    std::vector<uint64> chrom_lengths;  // genome-chromosome lengths
+    const T* chromosomes;               // pointer to `const T`
     uint64 read_length;                 // Length of reads
     bool paired;                        // Boolean for whether to do paired-end reads
     bool matepair;                      // Boolean for whether to do mate-pair reads
@@ -330,9 +329,9 @@ public:
                       const double& ins_prob2,
                       const double& del_prob2,
                       const std::string& barcode)
-        : chrom_sampler(),
-          qual_errors(),
+        : qual_errors(),
           frag_lengths(frag_len_shape, frag_len_scale),
+          chrom_reads(),
           chrom_lengths(chrom_object.chrom_sizes()),
           chromosomes(&chrom_object),
           read_length(qual_probs1[0].size()),
@@ -370,9 +369,9 @@ public:
                       const double& ins_prob,
                       const double& del_prob,
                       const std::string& barcode)
-        : chrom_sampler(),
-          qual_errors{IlluminaQualityError(qual_probs, quals)},
+        : qual_errors{IlluminaQualityError(qual_probs, quals)},
           frag_lengths(frag_len_shape, frag_len_scale),
+          chrom_reads(),
           chrom_lengths(chrom_object.chrom_sizes()),
           chromosomes(&chrom_object),
           read_length(qual_probs[0].size()),
@@ -392,9 +391,9 @@ public:
           };
 
     IlluminaOneGenome(const IlluminaOneGenome& other)
-        : chrom_sampler(other.chrom_sampler),
-          qual_errors(other.qual_errors),
+        : qual_errors(other.qual_errors),
           frag_lengths(other.frag_lengths),
+          chrom_reads(other.chrom_reads),
           chrom_lengths(other.chrom_lengths),
           chromosomes(other.chromosomes),
           read_length(other.read_length),
@@ -410,18 +409,35 @@ public:
           constr_info(other.constr_info) {};
 
 
+    void add_n_reads(uint64 n_reads) {
+
+        std::vector<double> probs_(chrom_lengths.begin(), chrom_lengths.end());
+        if (paired) n_reads /= 2; // now it's pairs of reads
+        chrom_reads = reads_per_group(n_reads, probs_);
+        if (paired) for (uint64& r : chrom_reads) r *= 2;  // back to # reads
+
+        return;
+    }
+
 
     // Sample one set of read strings (each with 4 lines: ID, chromosome, "+", quality)
     // `U` should be a std::string or std::vector<char>
     template <typename U>
-    void one_read(std::vector<U>& fastq_pools, pcg64& eng);
+    void one_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng);
+    // Overloaded for when we input a variant chromosome stored as string
+    template <typename U>
+    void one_read(const std::string& chrom, const uint64& chrom_i,
+                  std::vector<U>& fastq_pools, pcg64& eng);
 
     /*
      Same as above, but for a duplicate. It's assumed that `one_read` has been
      run once before.
      */
     template <typename U>
-    void re_read(std::vector<U>& fastq_pools, pcg64& eng);
+    void re_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng);
+    template <typename U>
+    void re_read(const std::string& chrom, const uint64& chrom_i,
+                 std::vector<U>& fastq_pools, pcg64& eng);
 
     /*
      Add information about a RefGenome or VarGenome object
@@ -460,11 +476,19 @@ protected:
      Sample a chromosome, indels, fragment length, and starting position for the fragment.
      Lastly, it sets the chromosome spaces required for these reads.
      */
-    void chrom_indels_frag(pcg64& eng);
+    void chrom_indels_frag(bool& finished, pcg64& eng);
 
 
     /*
-     Same as above, but for duplicates.
+     Sample indels, fragment length, and starting position for the fragment.
+     Lastly, it sets the chromosome spaces required for these reads.
+     This is for when the chromosome is already set.
+     */
+    void indels_frag(pcg64& eng);
+
+
+    /*
+     Same as `chrom_indels_frag`, but for duplicates.
      This means skipping the chromosome and fragment info parts.
      */
     void just_indels(pcg64& eng);
@@ -479,6 +503,8 @@ protected:
      */
     template <typename U>
     void append_pools(std::vector<U>& fastq_pools, pcg64& eng);
+    template <typename U>
+    void append_pools(const std::string& chrom, std::vector<U>& fastq_pools, pcg64& eng);
 
 
 };
@@ -498,9 +524,11 @@ class IlluminaVariants {
 public:
 
     const VarSet* variants;                         // pointer to `const VarSet`
-    AliasSampler variant_sampler;                   // chooses which variant to use
+    std::vector<std::vector<uint64>> n_reads_vc;    // # reads per variant and chromosome
     std::vector<IlluminaOneVariant> read_makers;    // makes Illumina reads
     bool paired;                                    // Boolean for paired-end reads
+    std::vector<double> var_probs;                  // probs of sampling variants
+
 
     IlluminaVariants() : variants(nullptr) {}
 
@@ -524,29 +552,31 @@ public:
                      const double& del_prob2,
                      std::vector<std::string> barcodes)
         : variants(&var_set),
-          variant_sampler(variant_probs),
+          n_reads_vc(),
           read_makers(),
           paired(true),
-          var(0) {
+          var_probs(variant_probs),
+          var(0),
+          chr(0),
+          var_chrom_seq(){
 
         if (barcodes.size() < var_set.size()) barcodes.resize(var_set.size(), "");
+
+        uint64 n_vars = variants->size();
 
         /*
          Fill `read_makers` field:
          */
-        uint64 n_vars = var_set.size();
-        // Read maker for the first variant:
-        IlluminaOneVariant read_maker1(var_set[0], matepair_,
-                                       frag_len_shape, frag_len_scale,
-                                       frag_len_min_, frag_len_max_,
-                                       qual_probs1, quals1, ins_prob1, del_prob1,
-                                       qual_probs2, quals2, ins_prob2, del_prob2,
-                                       barcodes[0]);
         read_makers.reserve(n_vars);
-        read_makers.push_back(read_maker1);
-        for (uint64 i = 1; i < n_vars; i++) {
-            read_makers.push_back(read_maker1);
-            read_makers[i].add_chrom_info(var_set[i], barcodes[i]);
+        for (uint64 i = 0; i < n_vars; i++) {
+            read_makers.push_back(
+                IlluminaOneVariant(var_set[i], matepair_,
+                                   frag_len_shape, frag_len_scale,
+                                   frag_len_min_, frag_len_max_,
+                                   qual_probs1, quals1, ins_prob1, del_prob1,
+                                   qual_probs2, quals2, ins_prob2, del_prob2,
+                                   barcodes[i])
+            );
         }
 
     };
@@ -564,35 +594,66 @@ public:
                      const double& del_prob,
                      std::vector<std::string> barcodes)
         : variants(&var_set),
-          variant_sampler(variant_probs),
+          n_reads_vc(),
           read_makers(),
           paired(false),
-          var(0) {
+          var_probs(variant_probs),
+          var(0),
+          chr(0),
+          var_chrom_seq() {
 
         if (barcodes.size() < var_set.size()) barcodes.resize(var_set.size(), "");
+
+        uint64 n_vars = var_set.size();
 
         /*
          Fill `read_makers` field:
          */
-        uint64 n_vars = var_set.size();
-        // Read maker for the first variant:
-        IlluminaOneVariant read_maker1(var_set[0],
-                                       frag_len_shape, frag_len_scale,
-                                       frag_len_min_, frag_len_max_,
-                                       qual_probs, quals, ins_prob, del_prob,
-                                       barcodes[0]);
         read_makers.reserve(n_vars);
-        read_makers.push_back(read_maker1);
-        for (uint64 i = 1; i < n_vars; i++) {
-            read_makers.push_back(read_maker1);
-            read_makers[i].add_chrom_info(var_set[i], barcodes[i]);
+        for (uint64 i = 0; i < n_vars; i++) {
+            read_makers.push_back(
+                IlluminaOneVariant(var_set[i],
+                                   frag_len_shape, frag_len_scale,
+                                   frag_len_min_, frag_len_max_,
+                                   qual_probs, quals, ins_prob, del_prob,
+                                   barcodes[i])
+            );
         }
 
     };
 
     IlluminaVariants(const IlluminaVariants& other)
-        : variants(other.variants), variant_sampler(other.variant_sampler),
-          read_makers(other.read_makers), paired(other.paired), var(other.var) {};
+        : variants(other.variants), n_reads_vc(other.n_reads_vc),
+          read_makers(other.read_makers), paired(other.paired),
+          var_probs(other.var_probs),
+          var(other.var), chr(other.chr), var_chrom_seq(other.var_chrom_seq) {};
+
+
+    // Add info on # reads
+    void add_n_reads(uint64 n_reads) {
+
+        uint64 n_vars = variants->size();
+
+        // split # reads by variant
+        if (paired) n_reads /= 2; // now it's pairs of reads
+        std::vector<uint64> var_reads = reads_per_group(n_reads, var_probs);
+        if (paired) for (uint64& r : var_reads) r *= 2;  // back to # reads
+        // splitting by chromosome, too:
+        for (uint64 v = 0; v < n_vars; v++) {
+            std::vector<double> chrom_probs;
+            for (const VarChrom& vc : (*variants)[v].chromosomes) {
+                chrom_probs.push_back(vc.size());
+            }
+            n_reads_vc.push_back(reads_per_group(var_reads[v], chrom_probs));
+        }
+
+        // Fill `read_makers` field:
+        for (uint64 i = 0; i < n_vars; i++) {
+            read_makers[i].add_n_reads(var_reads[i]);
+        }
+
+        return;
+    }
 
 
     /*
@@ -602,9 +663,43 @@ public:
      */
     // If only providing rng and id info, sample for a variant, then make read(s):
     template <typename U>
-    void one_read(std::vector<U>& fastq_pools, pcg64& eng) {
-        var = variant_sampler.sample(eng);
-        read_makers[var].one_read<U>(fastq_pools, eng);
+    void one_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng) {
+
+        if (var == variants->size()) {
+            finished = true;
+            return;
+        }
+
+        if (n_reads_vc[var][chr] == 0 || var_chrom_seq.empty()) {
+
+            uint64 new_var = var;
+            uint64 new_chr = chr;
+            for (; new_var < n_reads_vc.size(); new_var++) {
+                while (n_reads_vc[new_var][new_chr] == 0) {
+                    new_chr++;
+                    if (new_chr == n_reads_vc[new_var].size()) break;
+                }
+                if (new_chr < n_reads_vc[new_var].size()) {
+                    break;
+                } else new_chr = 0;
+            }
+
+            var = new_var;
+            chr = new_chr;
+
+            if (var == variants->size())  {
+                finished = true;
+                return;
+            }
+
+            var_chrom_seq = (*variants)[var][chr].get_chrom_full();
+        }
+
+        read_makers[var].one_read<U>(var_chrom_seq, chr, fastq_pools, eng);
+
+        n_reads_vc[var][chr]--;
+        if (paired && n_reads_vc[var][chr] > 0) n_reads_vc[var][chr]--;
+
         return;
     }
     /*
@@ -613,8 +708,18 @@ public:
      -------------
      */
     template <typename U>
-    void re_read(std::vector<U>& fastq_pools, pcg64& eng) {
-        read_makers[var].re_read<U>(fastq_pools, eng);
+    void re_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng) {
+
+        if (var == variants->size()) {
+            finished = true;
+            return;
+        }
+
+        read_makers[var].re_read<U>(var_chrom_seq, chr, fastq_pools, eng);
+
+        if (n_reads_vc[var][chr] > 0) n_reads_vc[var][chr]--;
+        if (paired && n_reads_vc[var][chr] > 0) n_reads_vc[var][chr]--;
+
         return;
     }
 
@@ -622,8 +727,12 @@ public:
 
 private:
 
-    // Variant to sample from. It's saved in this class in case of duplicates.
+    // Variant to create read from.
     uint64 var;
+    // Chromosome to create read from.
+    uint64 chr;
+    // String for variant chromosome. It's saved to make things faster.
+    std::string var_chrom_seq;
 
 };
 

--- a/src/hts_pacbio.cpp
+++ b/src/hts_pacbio.cpp
@@ -134,6 +134,7 @@ void PacBioQualityError::update_probs(pcg64& eng,
 template <typename T>
 template <typename U>
 void PacBioOneGenome<T>::one_read(std::vector<U>& fastq_pools,
+                                  bool& finished,
                                   pcg64& eng) {
 
     U& fastq_pool(fastq_pools[0]);
@@ -141,8 +142,14 @@ void PacBioOneGenome<T>::one_read(std::vector<U>& fastq_pools,
     /*
     Sample read info, and set the chromosome space(s) required for these read(s).
     */
-    // Sample chromosome:
-    chrom_ind = chrom_sampler.sample(eng);
+    // Get chromosome:
+    chrom_ind = 0;
+    while (chrom_ind < chrom_reads.size() && chrom_reads[chrom_ind] == 0) chrom_ind++;
+    if (chrom_ind == chrom_reads.size()) {
+        finished = true;
+        return;
+    }
+
     uint64 chrom_len = (*chromosomes)[chrom_ind].size();
 
     // Sample read length:
@@ -180,11 +187,64 @@ void PacBioOneGenome<T>::one_read(std::vector<U>& fastq_pools,
     return;
 }
 
+// Overloaded for when we input a variant chromosome stored as string
+template <typename T>
+template <typename U>
+void PacBioOneGenome<T>::one_read(const std::string& chrom,
+                                  const uint64& chrom_i,
+                                  std::vector<U>& fastq_pools,
+                                  pcg64& eng) {
+
+    U& fastq_pool(fastq_pools[0]);
+
+    chrom_ind = chrom_i;
+
+    uint64 chrom_len = (*chromosomes)[chrom_ind].size();
+
+    // Sample read length:
+    read_length = len_sampler.sample(eng);
+    if (read_length >= chrom_len) read_length = chrom_len;
+
+    // Sample for # passes over read:
+    pass_sampler.sample(split_pos, passes_left, passes_right, eng, read_length);
+
+    // Sample for errors and qualities:
+    qe_sampler.sample(eng, qual_left, qual_right, insertions, deletions, substitutions,
+                      chrom_len, read_length, split_pos, passes_left, passes_right);
+
+    /*
+     The amount of space on the reference/variant chromosome needed to create this read.
+     I'm adding deletions because more deletions mean that I need
+     more chromosome bases to achieve the same read length.
+     Insertions means I need fewer.
+     */
+    read_chrom_space = read_length + deletions.size() - insertions.size();
+
+    // Sample read starting position:
+    if (read_chrom_space < chrom_len) {
+        double u = runif_01(eng);
+        read_start = static_cast<uint64>(u * (chrom_len - read_chrom_space + 1));
+    } else if (read_chrom_space == chrom_len) {
+        read_start = 0;
+    } else {
+        stop("read_chrom_space should never exceed the chromosome length.");
+    }
+
+    // Fill the reads and qualities
+    append_pool<U>(chrom, fastq_pool, eng);
+
+    return;
+}
+
+
+
+
 
 
 template <typename T>
 template <typename U>
 void PacBioOneGenome<T>::re_read(std::vector<U>& fastq_pools,
+                                 bool& finished,
                                  pcg64& eng) {
 
     U& fastq_pool(fastq_pools[0]);
@@ -227,6 +287,60 @@ void PacBioOneGenome<T>::re_read(std::vector<U>& fastq_pools,
 
     return;
 }
+
+
+
+
+template <typename T>
+template <typename U>
+void PacBioOneGenome<T>::re_read(const std::string& chrom,
+                                 const uint64& chrom_i,
+                                 std::vector<U>& fastq_pools,
+                                 pcg64& eng) {
+
+    U& fastq_pool(fastq_pools[0]);
+
+    chrom_ind = chrom_i;
+
+    /*
+     Use the same read info as before.
+     */
+    uint64 chrom_len = (*chromosomes)[chrom_ind].size();
+
+    // Sample for # passes over read:
+    pass_sampler.sample(split_pos, passes_left, passes_right, eng, read_length);
+
+    // Sample for errors and qualities:
+    qe_sampler.sample(eng, qual_left, qual_right, insertions, deletions, substitutions,
+                      chrom_len, read_length, split_pos, passes_left, passes_right);
+
+    /*
+     The amount of space on the reference/variant chromosome needed to create this read.
+     I'm adding deletions because more deletions mean that I need
+     more chromosome bases to achieve the same read length.
+     Insertions means I need fewer.
+     */
+    read_chrom_space = read_length + deletions.size() - insertions.size();
+
+    /*
+     In the very rare situation where a duplication occurs, then enough deletions
+     happen where the required chromosome space exceeds what's available, I'm going
+     to remove deletions until we have enough room.
+     */
+    while ((read_chrom_space + read_start) > chrom_len) {
+        if (deletions.empty()) break;
+        deletions.pop_back();
+        read_chrom_space--;
+    }
+    // If that still doesn't work, I give up on the duplicate.
+    if ((read_chrom_space + read_start) > chrom_len) return;
+
+    // Fill the reads and qualities
+    append_pool<U>(chrom, fastq_pool, eng);
+
+    return;
+}
+
 
 
 
@@ -298,6 +412,145 @@ void PacBioOneGenome<T>::append_pool(U& fastq_pool, pcg64& eng) {
 
     return;
 }
+
+
+template <typename T>
+template <typename U>
+void PacBioOneGenome<T>::append_pool(const std::string& chrom,
+                                     U& fastq_pool,
+                                     pcg64& eng) {
+
+    // Make sure it has enough memory reserved:
+    fastq_pool.reserve(fastq_pool.size() + read_length * 3 + 10);
+
+    // Boolean for whether we take the reverse side:
+    bool reverse = runif_01(eng) < 0.5;
+
+    // ID line:
+    fastq_pool.push_back('@');
+    for (const char& c : name) fastq_pool.push_back(c);
+    fastq_pool.push_back('-');
+    for (const char& c : (*chromosomes)[chrom_ind].name) fastq_pool.push_back(c);
+    fastq_pool.push_back('-');
+    for (const char& c : std::to_string(read_start)) fastq_pool.push_back(c);
+    fastq_pool.push_back('-');
+    if (reverse) {
+        fastq_pool.push_back('R');
+    } else fastq_pool.push_back('F');
+    fastq_pool.push_back('\n');
+
+    // Fill in read:
+    fill_read__(chrom, read, 0, read_start, read_chrom_space);
+
+    // Reverse complement if necessary:
+    if (reverse) rev_comp(read, read_chrom_space);
+
+    /*
+     Adding read with errors:
+     */
+    uint64 read_pos = 0;
+    uint64 current_length = 0;
+    uint64 rndi;
+    while (current_length < read_length) {
+        if (!insertions.empty() && read_pos == insertions.front()) {
+            rndi = static_cast<uint64>(runif_01(eng) * 4);
+            fastq_pool.push_back(read[read_pos]);
+            fastq_pool.push_back(jlp::bases[rndi]);
+            insertions.pop_front();
+            current_length += 2;
+        } else if (!deletions.empty() && read_pos == deletions.front()) {
+            deletions.pop_front();
+        } else if (!substitutions.empty() && read_pos == substitutions.front()) {
+            rndi = static_cast<uint64>(runif_01(eng) * 3);
+            fastq_pool.push_back(mm_nucleos[nt_map[read[read_pos]]][rndi]);
+            substitutions.pop_front();
+            current_length++;
+        } else {
+            fastq_pool.push_back(read[read_pos]);
+            current_length++;
+        }
+        read_pos++;
+    }
+
+    fastq_pool.push_back('\n');
+    fastq_pool.push_back('+');
+    fastq_pool.push_back('\n');
+
+    // Adding qualities:
+    for (uint64 i = 0; i < split_pos; i++) fastq_pool.push_back(qual_left);
+    for (uint64 i = split_pos; i < read_length; i++) fastq_pool.push_back(qual_right);
+    fastq_pool.push_back('\n');
+
+    return;
+}
+
+
+
+
+
+
+// `one_read` method
+template <typename U>
+void PacBioVariants::one_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng) {
+
+
+    if (var == variants->size()) {
+        finished = true;
+        return;
+    }
+
+    if (n_reads_vc[var][chr] == 0 || var_chrom_seq.empty()) {
+
+        uint64 new_var = var;
+        uint64 new_chr = chr;
+        for (; new_var < n_reads_vc.size(); new_var++) {
+            while (n_reads_vc[new_var][new_chr] == 0) {
+                new_chr++;
+                if (new_chr == n_reads_vc[new_var].size()) break;
+            }
+            if (new_chr < n_reads_vc[new_var].size()) {
+                break;
+            } else new_chr = 0;
+        }
+
+        var = new_var;
+        chr = new_chr;
+
+        if (var == variants->size())  {
+            finished = true;
+            return;
+        }
+
+        var_chrom_seq = (*variants)[var][chr].get_chrom_full();
+    }
+
+    read_makers[var].one_read<U>(var_chrom_seq, chr, fastq_pools, eng);
+
+    n_reads_vc[var][chr]--;
+
+    return;
+
+}
+
+
+// `re_read` method (for duplicates)
+template <typename U>
+void PacBioVariants::re_read(std::vector<U>& fastq_pools, bool& finished, pcg64& eng) {
+
+    if (var == variants->size()) {
+        finished = true;
+        return;
+    }
+
+    read_makers[var].re_read<U>(var_chrom_seq, chr, fastq_pools, eng);
+
+    if (n_reads_vc[var][chr] > 0) n_reads_vc[var][chr]--;
+
+    return;
+
+}
+
+
 
 
 


### PR DESCRIPTION
Simulating sequencing from variants is much faster because each variant chromosome is generated once and stored in memory until no longer used.